### PR TITLE
Fix CI by downgrading matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "timelapsetracking"
-version = "0.0.2"
+version = "1.0.0"
 description = "Tracking code and scripts for the timelapse analysis project"
 authors = [
     {name = "Filip Sluzewski", email = "filip.sluzewski@alleninstitute.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 dependencies = [
     "aicsimageio",
     "fire",
-    "matplotlib",
+    "matplotlib<3.9",
     "numpy",
     "pandas",
     "scipy",


### PR DESCRIPTION
# Context
The build is broken because recent versions of matplotlib have removed `matplotlib.cm.get_cmap`. This PR keeps `aics-timelapse-tracking` on older matplotlib, in order to match the tracking used in the nuclear growth paper as closely as possible.

# Changes
Also, bump the version to 1.0.0 now that this repo is published.

# Testing
Automated tests only